### PR TITLE
Makes builds with optimization playable

### DIFF
--- a/graphics/environment.cpp
+++ b/graphics/environment.cpp
@@ -69,21 +69,19 @@ namespace syj
 
     }
 
-    bool environment::loadDaySkyBox(std::string path)
+    void environment::loadDaySkyBox(std::string path)
     {
         for(int a = 0; a<5; a++)
-        {
             skyTexturesSideDay[a].createFromFile(path + std::to_string(a) + ".png");
-        }
     }
 
-    bool environment::loadNightSkyBox(std::string path)
+    void environment::loadNightSkyBox(std::string path)
     {
         for(int a = 0; a<5; a++)
             skyTexturesSideNight[a].createFromFile(path + std::to_string(a) + ".png");
     }
 
-    bool environment::loadSunModel(std::string path)
+    void environment::loadSunModel(std::string path)
     {
         sun = new model(path);
     }

--- a/graphics/environment.h
+++ b/graphics/environment.h
@@ -117,9 +117,9 @@ namespace syj
         void shadowsCalc(perspectiveCamera *playerCamera,glm::vec3 shadowDir);
         void calc(float deltaMS,perspectiveCamera *playerCamera);
         void passUniforms(uniformsHolder *uniforms,bool forgoShadowMaps = false);
-        bool loadDaySkyBox(std::string path);
-        bool loadNightSkyBox(std::string path);
-        bool loadSunModel(std::string path);
+        void loadDaySkyBox(std::string path);
+        void loadNightSkyBox(std::string path);
+        void loadSunModel(std::string path);
         void drawSun(uniformsHolder *uniforms);
         void drawSky(uniformsHolder *uniforms);
         void renderGodRays(uniformsHolder *uniforms);

--- a/graphics/model.cpp
+++ b/graphics/model.cpp
@@ -409,7 +409,7 @@ namespace syj
 
     glm::vec4 postovec4(glm::vec3 a){return glm::vec4(a.x,a.y,a.z,1.0);}
 
-    glm::mat4 node::transformCollisionMeshes(glm::vec3 &totalColMin,glm::vec3 &totalColMax,glm::mat4 startTransform)
+    void node::transformCollisionMeshes(glm::vec3 &totalColMin,glm::vec3 &totalColMax,glm::mat4 startTransform)
     {
         startTransform = startTransform * transform;
 

--- a/graphics/model.h
+++ b/graphics/model.h
@@ -69,7 +69,7 @@ namespace syj
         std::vector<mesh*> meshes;
         glm::mat4 transform = glm::mat4(1.0);
 
-        glm::mat4 transformCollisionMeshes(glm::vec3 &totalColMin,glm::vec3 &totalColMax,glm::mat4 startTransform = glm::mat4(1.0));
+        void transformCollisionMeshes(glm::vec3 &totalColMin,glm::vec3 &totalColMax,glm::mat4 startTransform = glm::mat4(1.0));
         void render(uniformsHolder *graphics,glm::mat4 startTransform,bool skipMats = false,std::vector<glm::vec3> *nodeColors = 0,texture *decal = 0);
         void renderForPicking(uniformsHolder *graphics,glm::mat4 startTransform);
         node(aiNode *source,model *_modelParent,int debugIndent = 0);

--- a/graphics/newBrickType.cpp
+++ b/graphics/newBrickType.cpp
@@ -41,6 +41,7 @@ namespace syj
             case swirl: return "Hologram";
             case slippery: return "Slippery";
             case foil: return "Foil";
+            default: return "Unknown";
         }
     }
 

--- a/gui/contentDownload.cpp
+++ b/gui/contentDownload.cpp
@@ -97,6 +97,7 @@ bool enableAllCustomFiles(const CEGUI::EventArgs &e)
     }
 
     serverListGUI->handleUpdatedItemData();
+    return true;
 }
 
 bool disableAllCustomFiles(const CEGUI::EventArgs &e)
@@ -130,6 +131,7 @@ bool disableAllCustomFiles(const CEGUI::EventArgs &e)
     }
 
     serverListGUI->handleUpdatedItemData();
+    return true;
 }
 
 bool joinFromCustomContentWindow(const CEGUI::EventArgs &e)
@@ -139,6 +141,7 @@ bool joinFromCustomContentWindow(const CEGUI::EventArgs &e)
 
     clientStuff *clientEnvironment = (clientStuff*)serverListGUI->getUserData();
     clientEnvironment->waitingOnContentList = false;
+    return true;
 }
 
 bool cancelFromCustomContentWindow(const CEGUI::EventArgs &e)
@@ -149,6 +152,7 @@ bool cancelFromCustomContentWindow(const CEGUI::EventArgs &e)
     clientStuff *clientEnvironment = (clientStuff*)serverListGUI->getUserData();
     clientEnvironment->cancelCustomContent = true;
     contentWindow->setVisible(false);
+    return true;
 }
 
 void addCustomFileToGUI(std::string name,std::string path,unsigned int checksum,unsigned int size,unsigned char type,int id)

--- a/gui/joinServer.cpp
+++ b/gui/joinServer.cpp
@@ -17,12 +17,14 @@ namespace syj
     {
         CEGUI::Window *updater = CEGUI::System::getSingleton().getDefaultGUIContext().getRootWindow()->getChild("Updater");
         updater->setVisible(true);
+        return true;
     }
 
     bool optionsButton(const CEGUI::EventArgs &e)
     {
         CEGUI::Window *optionsWindow = CEGUI::System::getSingleton().getDefaultGUIContext().getRootWindow()->getChild("Options");
         optionsWindow->setVisible(true);
+        return true;
     }
 
     size_t verifyLogin(void *buffer,size_t size,size_t nmemb,void *userp)
@@ -259,6 +261,7 @@ namespace syj
         curl_easy_setopt(curlHandle,CURLOPT_POSTFIELDS,args.c_str());
         CURLcode res = curl_easy_perform(curlHandle);
         curl_easy_cleanup(curlHandle);
+        return true;
     }
 
     bool connectToServer(const CEGUI::EventArgs &e)
@@ -323,6 +326,7 @@ namespace syj
         if(!clientEnvironment)
             return true;
         clientEnvironment->clickedMainMenuExit = true;
+        return true;
     }
 
     CEGUI::Window *loadJoinServer(clientStuff *clientEnvironment)

--- a/gui/updater.cpp
+++ b/gui/updater.cpp
@@ -409,6 +409,7 @@ namespace syj
         ((clientStuff*)updater->getUserData())->prefs->set("REVISION",((clientStuff*)updater->getUserData())->masterRevision);
         ((clientStuff*)updater->getUserData())->prefs->set("NETWORK",((clientStuff*)updater->getUserData())->masterNetwork);
         ((clientStuff*)updater->getUserData())->prefs->exportToFile("config.txt");
+        return true;
     }
 
     CEGUI::Window *addUpdater(clientStuff *clientEnvironment)

--- a/gui/updater.cpp
+++ b/gui/updater.cpp
@@ -237,6 +237,13 @@ namespace syj
             std::string fileName = line.substr(0,firstTab);
 #ifdef __linux__ 
             replaceAll(fileName,"\\","/");
+            std::string::size_type idx = fileName.rfind('.');
+            if(idx != std::string::npos)  {
+                std::string extension = fileName.substr(idx + 1);
+                if(extension == "exe" || extension == "dll") {
+                    continue;
+                }
+            }
 #endif
             std::string afterFirstTab = line.substr(firstTab+1,line.length()-(firstTab+1));
 

--- a/main.cpp
+++ b/main.cpp
@@ -74,6 +74,8 @@ bool godRayButton(const CEGUI::EventArgs &e)
     clientEnvironment->serverData->env->godRayExposure = atof(godRayWindow->getChild("Exposure")->getText().c_str());
     clientEnvironment->serverData->env->godRayWeight = atof(godRayWindow->getChild("Weight")->getText().c_str());
     clientEnvironment->serverData->env->sunDistance = atof(godRayWindow->getChild("Distance")->getText().c_str());
+
+    return true;
 }
 
 enum gameState
@@ -131,7 +133,7 @@ int main(int argc, char *argv[])
     info("Our revision: " + std::to_string(ourRevisionVersion));
 
     renderContextOptions renderOptions;
-    renderOptions.name = "Rev " + std::to_string(ourRevisionVersion) + " - " + __DATE__;
+    renderOptions.name = "Rev " + std::to_string(ourRevisionVersion) + LOD_BUILD_AND_DATE;
     renderOptions.startingResX = clientEnvironment.settings->resolutionX;
     renderOptions.startingResY = clientEnvironment.settings->resolutionY;
     renderOptions.useVSync = clientEnvironment.settings->vsync;

--- a/networking/common.h
+++ b/networking/common.h
@@ -20,8 +20,9 @@
 //Code for the server
 //#include "server.h"
 
-//A custom getline for Linux Compatibility
+//Linux specific code
 #ifdef __linux__
+    #define LOD_BUILD_AND_DATE " - " + __DATE__ + " (Linux)"
     inline std::istream& lodGetLine(std::istream& is, std::string& t)
     {
         t.clear();
@@ -38,6 +39,7 @@
         }
     }
 #else
+    #define LOD_BUILD_AND_DATE " - " + __DATE__
     #define lodGetLine(file, line) std::getline(file, line)
 #endif
 

--- a/networking/common.h
+++ b/networking/common.h
@@ -22,7 +22,7 @@
 
 //A custom getline for Linux Compatibility
 #ifdef __linux__
-    std::istream& lodGetLine(std::istream& is, std::string& t)
+    inline std::istream& lodGetLine(std::istream& is, std::string& t)
     {
         t.clear();
         std::istream::sentry se(is, true);

--- a/networking/location.cpp
+++ b/networking/location.cpp
@@ -8,8 +8,7 @@ namespace syj
     {
         switch(type)
         {
-            case brickPos:
-            case worldPos:
+            default: //brickPos, worldPos
                 return direction;
 
             case itemNode:
@@ -135,8 +134,7 @@ namespace syj
     {
         switch(type)
         {
-            case worldPos:
-            case brickPos:
+            default: //worldPos, brickPos
                 return fixedPos;
             /*case brickPos:
                 if(!brick)


### PR DESCRIPTION
**Advice for dran:** I highly suggest you enable "-Werror=return-type" because it can cause undefined behaviour when gone unnoticed, this won't show in debug builds but it shows when optimized and it's the main reason LoD (mostly) didn't work with optimizations and please look at the warnings GCC produces, it's not a lot and you can supress the non important ones with "-Wno-sign-compare -Wno-unused-variable" which leaves you with the most relevant ones.